### PR TITLE
Upgraded mods to recent versions, improved docs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN mkdir -p /var/lib/mercurio &&\
 RUN mkdir -p /usr/share/minetest/mods &&\
     cd /usr/share/minetest &&\
     contentdb install --debug --url=https://contentdb.ronoaldo.net \
-        apercy/trike@9174 \
-        apercy/hidroplane@9505 \
+        apercy/trike@9794 \
+        apercy/hidroplane@9880 \
         apercy/motorboat@8453 \
-        apercy/demoiselle@9542 \
+        apercy/demoiselle@9812 \
         AiTechEye/smartshop@903 \
         BuckarooBanzay/mapserver@7753 \
         bell07/carpets@3671 \
@@ -26,11 +26,11 @@ RUN mkdir -p /usr/share/minetest/mods &&\
         ElCeejo/mob_core@8939 \
         FaceDeer/anvil@5696 \
         FaceDeer/hopper@6074 \
-        Gundul/water_life@8632 \
+        Gundul/water_life@9651 \
         "Hybrid Dog/we_undo@9288" \
-        JAstudios/moreswords@4890 \
+        JAstudios/moreswords@9585 \
         Jeija/digilines@8574 \
-        Jeija/mesecons@9054 \
+        Jeija/mesecons@9802 \
         joe7575/lumberjack@7252 \
         jp/xdecor@8625 \
         Liil/nativevillages@7404 \
@@ -44,28 +44,28 @@ RUN mkdir -p /usr/share/minetest/mods &&\
         philipmi/regrowing_fruits@5746 \
         Piezo_/illumination@1091 \
         PilzAdam/nether@8686 \
-        RealBadAngel/unified_inventory@9494 \
+        RealBadAngel/unified_inventory@9734 \
         rnd/basic_machines@58 \
         rubenwardy/awards@6092 \
         ShadowNinja/areas@5030 \
         Shara/abriglass@32 \
-        sfan5/worldedit@6305 \
+        sfan5/worldedit@9572 \
         sofar/crops@176 \
         sofar/emote@1317 \
         Sokomine/markers@306 \
         Sokomine/replacer@76 \
-        stu/3d_armor@8731 \
+        stu/3d_armor@9664 \
         TenPlus1/bakedclay@9438 \
         TenPlus1/bonemeal@9389 \
         TenPlus1/dmobs@9170 \
-        TenPlus1/ethereal@9419 \
-        TenPlus1/farming@9420 \
+        TenPlus1/ethereal@9788 \
+        TenPlus1/farming@9879 \
         TenPlus1/itemframes@7148 \
-        TenPlus1/mob_horse@9514 \
-        TenPlus1/mobs@9324 \
-        TenPlus1/mobs_animal@8611 \
-        TenPlus1/mobs_monster@9202 \
-        TenPlus1/mobs_npc@8610 \
+        TenPlus1/mob_horse@9669 \
+        TenPlus1/mobs@9680 \
+        TenPlus1/mobs_animal@9670 \
+        TenPlus1/mobs_monster@9671 \
+        TenPlus1/mobs_npc@9672 \
         TenPlus1/protector@9538 \
         Termos/mobkit@6391 \
         Traxie21/tpr@8314 \
@@ -88,7 +88,6 @@ RUN mkdir -p /usr/share/minetest/mods &&\
 RUN apt-get update && apt-get install git -yq && apt-get clean &&\
     cd /usr/share/minetest/mods &&\
     git clone --depth=1 https://github.com/APercy/airutils &&\
-    git clone --depth=1 https://github.com/APercy/helicopter &&\
     git clone --depth=1 https://github.com/berengma/aviator &&\
     git clone --depth=1 https://github.com/cx384/filler &&\
     git clone --depth=1 https://github.com/ronoaldo/minenews &&\
@@ -96,7 +95,8 @@ RUN apt-get update && apt-get install git -yq && apt-get clean &&\
     git clone --depth=1 https://github.com/ronoaldo/extra_doors &&\
     git clone --depth=1 https://github.com/ronoaldo/minetest-nether-monsters nether_mobs &&\
     git clone --depth=1 https://github.com/ronoaldo/x_bows &&\
-    git clone --depth=1 https://github.com/ronoaldo/hbsprint
+    git clone --depth=1 https://github.com/ronoaldo/hbsprint &&\
+    git clone --depth=1 --branch=before https://github.com/APercy/helicopter
 # Fetch all skins from database
 # TODO(ronoaldo): limit to selected skins to avoid abuse
 ADD fetch-skins.sh /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -1,22 +1,73 @@
 # Mercurio Minetest Server
 
-Hosting implementation of minetest server using custom Docker images.
+Hosting implementation of minetest server using custom Docker image
+for the Mercurio minetest server.
 
 ## Developing locally
 
 You need to have both `docker` and `docker composer` installed and working, and
 optionally you can use `make` to run the scripts more easily.
 
+In order to change some settings, copy the docker-compose.dev.yml as a local
+override:
+
+    cp docker-compose.dev.yml docker-compose.override.yml
+
+### Run a local server
+
 To test locally, you can use:
 
-    make run
+    make run-interactive
 
-To make a backup, use:
+This command will use `docker compose` to execute all the services needed,
+including a local PostgreSQL database, the Mapserver backend and the game
+server itself.
+
+To test the server, launch the minetest client and connect with `127.0.0.1`
+and port `30000`.
+
+### Local data storage
+
+The containers will store data in a `.minetest` folder in the current directory.
+The game data will be in `.minetest/world`, and the database files are under
+`.minetest/db`.
+
+To make a backup you can use the following make target:
 
     make backup
 
 Backups will be stored in $HOME/backups/
 
-To enter a debug shell, you can use:
+### Container shell
+
+Sometimes you may want to open a shell interpreter inside the running container,
+in order to check if all things are right. There is a make target for that as well:
 
     make shell
+
+This will open a shell with `root` privileges so you can debug the game server.
+
+### Troubheshooting
+
+Sometimes you may run into permission issues. I'm not sure why/how to fix
+them permanently, but I have made a small shell script to fix them as a
+workaround:
+
+    make fix-perms
+
+This one requires your login shell to have `sudo` privileges.
+
+## Updating mods
+
+For this implementation, I'm considering both game files as well as mod code
+to be part of the "game codebase". Thus, as much as possible, mods are *pinned*
+to specific versions.
+
+In order to check for updates, you can use the `contentdb` program inside the
+container either manually via the `make shell` program, or using the convenient
+target:
+
+    make check-mod-updates
+
+The output will print all mods with newer versions on Contentdb, and which Git
+mods can be updated.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+# Use this file in order to run a local/dev copy of the server.
+# Rename it to docker-compose.override.yml
+version: "3.3"
+services:
+  db:
+    restart: "no"
+    logging:
+      driver: "json-file"
+  game:
+    restart: "no"
+    logging:
+      driver: "json-file"
+    image: ghcr.io/ronoaldo/mercurio:beta
+    ports:
+      - "30000:30000/udp"
+      - "30000:30000/tcp"
+  mapserver:
+    restart: "no"


### PR DESCRIPTION
Added better instructions on how to dev/test locally with Docker Composer
and Make.

Updated mods:
* apercy/trike to Rev 9794
* apercy/hidroplane to Rev 9880
* apercy/demoiselle to Rev 9812
* Gundul/water_life to Rev 9651
* JAstudios/moreswords to Rev 9585
* Jeija/mesecons to Rev 9802
* RealBadAngel/unified_inventory to Rev 9734
* sfan5/worldedit to Rev 9572
* stu/3d_armor to Rev 9664
* TenPlus1/ethereal to Rev 9788
* TenPlus1/farming to Rev 9879
* TenPlus1/mob_horse to Rev 9669
* TenPlus1/mobs to Rev 9680
* TenPlus1/mobs_animal to Rev 9670
* TenPlus1/mobs_monster to Rev 9671
* TenPlus1/mobs_npc to Rev 9672

Closes #22 