### PR TITLE
Fixes nodes bellow and enderman spawning

### DIFF
--- a/.github/workflows/test-pr-build.yaml
+++ b/.github/workflows/test-pr-build.yaml
@@ -1,0 +1,37 @@
+name: Test docker image builds for pull-requests
+
+on:
+  push:
+    branches-ignore: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=r{{date 'YYYYMMDD'}}
+
+      - name: Test Docker image build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p /usr/share/minetest/mods &&\
         Piezo_/illumination@1091 \
         PilzAdam/nether@8686 \
         RealBadAngel/unified_inventory@9494 \
+        rael5/nether_mobs@6364 \
         rnd/basic_machines@58 \
         rubenwardy/awards@6092 \
         ShadowNinja/areas@5030 \
@@ -94,7 +95,6 @@ RUN apt-get update && apt-get install git -yq && apt-get clean &&\
     git clone --depth=1 https://github.com/ronoaldo/minenews &&\
     git clone --depth=1 https://github.com/ronoaldo/patron &&\
     git clone --depth=1 https://github.com/ronoaldo/extra_doors &&\
-    git clone --depth=1 https://github.com/ronoaldo/minetest-nether-monsters nether_mobs &&\
     git clone --depth=1 https://github.com/ronoaldo/x_bows &&\
     git clone --depth=1 https://github.com/ronoaldo/hbsprint
 # Fetch all skins from database

--- a/mercurio/init.lua
+++ b/mercurio/init.lua
@@ -10,6 +10,17 @@ local function fmt_pos(pos)
     return minetest.pos_to_string(pos, 0)
 end
 
+local function to_json(val)
+    if val == nil then
+        return "null"
+    end
+    local str = minetest.write_json(val)
+    if str == nil then
+        return "null"
+    end
+    return str
+end
+
 log_action("Initializing server overrides ...")
 
 -- PvP area as defined by the server settings.
@@ -75,5 +86,34 @@ remove_entity(":dmobs:nyan")
 remove_entity(":loot_crates:common")
 remove_entity(":loot_crates:uncommon")
 remove_entity(":loot_crates:rare")
+
+-- Spawn overrides
+local _orig_spawn_check = mobs.spawn_abm_check
+local function spawn_abm_check(self, pos, node, name)
+    if name == "nether_mobs:netherman" then
+        if pos.y >= -3000 then
+            return true
+        end
+    end
+    return _orig_spawn_check(pos, node, name)
+end
+mobs.spawn_abm_check = spawn_abm_check
+-- Debug spawning mobs from mobs_redo:
+log_action("Spawning mobs: " .. minetest.write_json(mobs.spawning_mobs))
+
+-- LBM to fix Nether unknown blocks already created
+minetest.register_lbm({
+    label = "Fix unknown nodes bellow Nether",
+    name = "mercurio:bellow_nether_fix",
+    nodenames = {"nether:native_mapgen"},
+    runt_at_every_load = true,
+    action = function(pos, node)
+        if pos.y >= -11000 then
+            return
+        end
+        log_action("Fixing Nether node node at pos "..to_json(pos))
+        minetest.set_node(pos, {name="default:stone"})
+    end,
+})
 
 log_action("Server overrides loaded!")

--- a/mercurio/init.lua
+++ b/mercurio/init.lua
@@ -89,7 +89,7 @@ remove_entity(":loot_crates:rare")
 
 -- Spawn overrides
 local _orig_spawn_check = mobs.spawn_abm_check
-local function spawn_abm_check(self, pos, node, name)
+local function mercurio_spawn_abm_check(self, pos, node, name)
     if name == "nether_mobs:netherman" then
         if pos.y >= -3000 then
             return true
@@ -97,17 +97,18 @@ local function spawn_abm_check(self, pos, node, name)
     end
     return _orig_spawn_check(pos, node, name)
 end
-mobs.spawn_abm_check = spawn_abm_check
+mobs.spawn_abm_check = mercurio_spawn_abm_check
 -- Debug spawning mobs from mobs_redo:
-log_action("Spawning mobs: " .. minetest.write_json(mobs.spawning_mobs))
+log_action("mobs.spawning_mobs = " .. minetest.write_json(mobs.spawning_mobs))
 
--- LBM to fix Nether unknown blocks already created
-minetest.register_lbm({
+-- ABM to fix Nether unknown blocks already created
+minetest.register_abm({
     label = "Fix unknown nodes bellow Nether",
-    name = "mercurio:bellow_nether_fix",
     nodenames = {"nether:native_mapgen"},
-    runt_at_every_load = true,
-    action = function(pos, node)
+    interval = 1.0,
+    chance = 1,
+    catch_up = true,
+    action = function(pos, node, active_object_count, active_object_count_wider)
         if pos.y >= -11000 then
             return
         end

--- a/mercurio/mod.conf
+++ b/mercurio/mod.conf
@@ -1,2 +1,2 @@
 name=mercurio
-depends=bakedclay, moreores, ethereal, xdecor
+depends=default, bakedclay, moreores, ethereal, xdecor, nether_mobs, nether, mobs

--- a/minetest.conf
+++ b/minetest.conf
@@ -2279,3 +2279,8 @@ mapserver.url = http://mapserver:8080
 mapserver.key = $(MERCURIO_MAPSERVER_KEY)
 mapserver.enable_crafting = true
 mapserver.send_interval = 1
+
+#   nether
+# Attempt to fix #14 for new blocks generated
+# (ref: https://github.com/minetest-mods/nether/issues/51)
+nether_depth_ymin = -11072


### PR DESCRIPTION
Fixes the nodes bellow nether using an ABM that replaces nether:default_mapgen
into default:stone. (Fixes #14)

Also fixes the Enderman spawning outside Nether realm, using a custom spawn
check function. (Fixes #21)