### PR TITLE
Update server engine to 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Pinned ghcr.io/ronoaldo/minetestserver:stable-5 release
-FROM ghcr.io/ronoaldo/minetestserver:stable-5
+FROM ghcr.io/ronoaldo/minetestserver:5.6.0
 
 # Setup system-wide settings
 USER root


### PR DESCRIPTION
Server base image is now based on Minetest 5.6
and Minetest Game 5.6, wich has shadows enabled.

Fixes #105